### PR TITLE
KillEveProcess implementation

### DIFF
--- a/src/Sanderling/Sanderling.Exe/App.Motor.cs
+++ b/src/Sanderling/Sanderling.Exe/App.Motor.cs
@@ -46,11 +46,6 @@ namespace Sanderling.Exe
 			{
 				var Process = System.Diagnostics.Process.GetProcessById(EveOnlineClientProcessId.Value);
 
-				if (null == Process)
-				{
-					return null;
-				}
-
 				return new Motor.WindowMotor(Process.MainWindowHandle);
 			}
 			catch (ArgumentException)
@@ -78,8 +73,6 @@ namespace Sanderling.Exe
 					  return null;
 				  }
 
-				  var MotorAsWindowMotor = Motor as Motor.WindowMotor;
-
 				  var BeginTime = GetTimeStopwatch();
 
 				  var Result = Motor.ActSequenceMotion(motion.AsSequenceMotion(MemoryMeasurementLast?.Value?.MemoryMeasurement));
@@ -99,5 +92,5 @@ namespace Sanderling.Exe
 		}
 
 		MotionResult FromScriptMotionExecute(MotionParam motionParam) => ActMotionAsync(motionParam).Result;
-	}
+    }
 }

--- a/src/Sanderling/Sanderling.Exe/App.xaml.cs
+++ b/src/Sanderling/Sanderling.Exe/App.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using Bib3;
-using BotEngine.Interface;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -41,7 +40,7 @@ namespace Sanderling.Exe
 
 			UIAPI = new Sanderling.Script.Impl.HostToScript
 			{
-				MemoryMeasurementFunc = new Func<FromProcessMeasurement<Interface.MemoryMeasurementEvaluation>>(() => MemoryMeasurementLast),
+				MemoryMeasurementFunc = () => MemoryMeasurementLast,
 			};
 		}
 
@@ -91,6 +90,7 @@ namespace Sanderling.Exe
 				FromScriptRequestMemoryMeasurementEvaluation = FromScriptRequestMemoryMeasurementEvaluation,
 				FromScriptMotionExecute = FromScriptMotionExecute,
 				GetWindowHandleDelegate = () => Motor?.WindowHandle ?? IntPtr.Zero,
+                GetKillEveProcessAction = KillEveProcessAction
 			};
 		}
 
@@ -143,12 +143,12 @@ namespace Sanderling.Exe
 
 			if (null != OriginalSource)
 			{
-				if (OriginalSource == ToggleButtonMotionEnable?.ButtonLinx)
+				if (Equals(OriginalSource, ToggleButtonMotionEnable?.ButtonLinx))
 				{
 					ScriptRunPause();
 				}
 
-				if (OriginalSource == ToggleButtonMotionEnable?.ButtonRecz)
+				if (Equals(OriginalSource, ToggleButtonMotionEnable?.ButtonRecz))
 				{
 					ScriptRunPlay();
 				}
@@ -169,7 +169,20 @@ namespace Sanderling.Exe
 			UIPresentScript();
 		}
 
-		private void Application_DispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
+        private void KillEveProcessAction()
+        {
+            Current.Dispatcher.Invoke(() =>
+            {
+                if (!EveOnlineClientProcessId.HasValue)
+                    return;
+
+                var process = System.Diagnostics.Process.GetProcessById(EveOnlineClientProcessId.Value);
+
+                process.Kill();
+            });
+        }
+
+        private void Application_DispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
 		{
 			try
 			{

--- a/src/Sanderling/Sanderling/Script/IHostToScript.cs
+++ b/src/Sanderling/Sanderling/Script/IHostToScript.cs
@@ -42,6 +42,11 @@ namespace Sanderling.Script
 		void InvalidateMeasurement(int delayToMeasurementMilli);
 
 		IntPtr WindowHandle { get; }
+
+        /// <summary>
+        /// Instantly kill currently monitored EVE Online process
+        /// </summary>
+	    void KillEveProcess();
 	}
 
 	public class ToScriptGlobals : BotSharp.ScriptRun.ScriptRun.ToScriptGlobals

--- a/src/Sanderling/Sanderling/Script/Impl/HostToScript.cs
+++ b/src/Sanderling/Sanderling/Script/Impl/HostToScript.cs
@@ -16,7 +16,9 @@ namespace Sanderling.Script.Impl
 
 		public Action<int> InvalidateMeasurementAction;
 
-		public Func<IntPtr> WindowHandleFunc;
+        public Action KillEveProcessAction;
+
+        public Func<IntPtr> WindowHandleFunc;
 
 		public FromProcessMeasurement<MemoryStruct.IMemoryMeasurement> MemoryMeasurement =>
 			MemoryMeasurementFunc?.Invoke()?.MapValue(evaluation => evaluation?.MemoryMeasurement);
@@ -32,5 +34,7 @@ namespace Sanderling.Script.Impl
 		public void InvalidateMeasurement(Int32 delayToMeasurementMilli) => InvalidateMeasurementAction?.Invoke(delayToMeasurementMilli);
 
 		public IntPtr WindowHandle => WindowHandleFunc?.Invoke() ?? IntPtr.Zero;
+
+	    public void KillEveProcess() => KillEveProcessAction?.Invoke();
 	}
 }

--- a/src/Sanderling/Sanderling/Script/Impl/ScriptRunClient.cs
+++ b/src/Sanderling/Sanderling/Script/Impl/ScriptRunClient.cs
@@ -20,6 +20,8 @@ namespace Sanderling.Script.Impl
 
 		public Action<int> InvalidateMeasurementAction;
 
+		public Action GetKillEveProcessAction;
+
 		public Func<IntPtr> GetWindowHandleDelegate;
 
 		public Func<MotionParam, MotionResult> FromScriptMotionExecute;
@@ -44,6 +46,8 @@ namespace Sanderling.Script.Impl
 					InvalidateMeasurementAction = InvalidateMeasurementAction,
 
 					WindowHandleFunc = () => GetWindowHandleDelegate?.Invoke() ?? IntPtr.Zero,
+
+                    KillEveProcessAction = () => GetKillEveProcessAction?.Invoke(),
 				}
 			};
 


### PR DESCRIPTION
The change allows to call KillEveProcess directly from the scripts to instantly kill currently monitored game client. Useful to initiate emergency warp without interaction with the game client. 

Also did code clean-up changes and replaced == reference comparison with Equals as it's much safer.