### PR TITLE
Save and restore main window size and position

### DIFF
--- a/src/Sanderling/Sanderling.Exe/MainWindow.xaml
+++ b/src/Sanderling/Sanderling.Exe/MainWindow.xaml
@@ -7,7 +7,7 @@
         xmlns:Sanderling.UI="clr-namespace:Sanderling.UI;assembly=Sanderling.UI"
         mc:Ignorable="d"
         Title="{Binding RelativeSource={RelativeSource Self}, Path=TitleComputed, FallbackValue=Sanderling vXXXX}"
-        Height="350" Width="525">
+        >
     <Window.Resources>
         <ResourceDictionary Source="pack://application:,,,/Sanderling.Exe;component/resource.xaml"></ResourceDictionary>
     </Window.Resources>

--- a/src/Sanderling/Sanderling.Exe/MainWindow.xaml.cs
+++ b/src/Sanderling/Sanderling.Exe/MainWindow.xaml.cs
@@ -10,7 +10,13 @@ namespace Sanderling.Exe
 		public MainWindow()
 		{
 			InitializeComponent();
-		}
+
+            State.Tracker.Configure(this)//the object to track
+                .IdentifyAs("Main Sanderling Window")//a string by which to identify the target object
+                .AddProperties<Window>(w => w.Height, w => w.Width, w => w.Top, w => w.Left, w => w.WindowState)//properties to track
+                .RegisterPersistTrigger(nameof(SizeChanged))//when to persist data to the store
+                .Apply();//apply any previously stored data
+        }
 
 		public string TitleComputed =>
 			"Sanderling v" + (TryFindResource("AppVersionId") ?? "");

--- a/src/Sanderling/Sanderling.Exe/Sanderling.Exe.csproj
+++ b/src/Sanderling/Sanderling.Exe/Sanderling.Exe.csproj
@@ -79,6 +79,9 @@
       <HintPath>..\packages\AvalonEdit.5.0.3\lib\Net40\ICSharpCode.AvalonEdit.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Jot, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Jot.1.3.11\lib\Jot.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
@@ -225,6 +228,7 @@
     <Compile Include="App.UI.cs" />
     <EmbeddedResource Include="sample\script\Mine.ore.cs" />
     <Compile Include="Script\ToScriptGlobals.cs" />
+    <Compile Include="State.cs" />
     <Compile Include="ToScriptImport.cs" />
     <EmbeddedResource Include="sample\script\Travel.simple.cs" />
     <Page Include="MainWindow.xaml">

--- a/src/Sanderling/Sanderling.Exe/State.cs
+++ b/src/Sanderling/Sanderling.Exe/State.cs
@@ -1,0 +1,9 @@
+﻿using Jot;
+
+namespace Sanderling.Exe
+{
+    internal static class State
+    {
+        public static StateTracker Tracker = new StateTracker();
+    }
+}

--- a/src/Sanderling/Sanderling.Exe/packages.config
+++ b/src/Sanderling/Sanderling.Exe/packages.config
@@ -5,6 +5,7 @@
   <package id="Costura.Fody" version="1.3.5.0" targetFramework="net461" developmentDependency="true" />
   <package id="fasterflect" version="2.1.3" targetFramework="net461" />
   <package id="Fody" version="1.29.4" targetFramework="net461" developmentDependency="true" />
+  <package id="Jot" version="1.3.11" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.Common" version="1.3.2" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.CSharp" version="1.3.2" targetFramework="net461" />


### PR DESCRIPTION
This change will allow to persist main window size and position whenever it gets updated and restore upon launching Sanderling.
Added nuget package dependency - https://github.com/anakic/Jot . It allows to easily track application state not touching the App.config with minimal coding. Very useful and easy to use.