### PR TITLE
ModuleTooltip: remove XML-tags from labels before matching with regex

### DIFF
--- a/src/Sanderling/Sanderling/Parse/ModuleButtonTooltip.cs
+++ b/src/Sanderling/Sanderling/Parse/ModuleButtonTooltip.cs
@@ -148,7 +148,7 @@ namespace Sanderling.Parse
 			}
 
 			var LabelRegexMatchSuccessIgnoreCase = new Func<string, bool>(
-				pattern => raw?.LabelText?.Any(label => label?.Text?.RegexMatchSuccess(pattern, System.Text.RegularExpressions.RegexOptions.IgnoreCase) ?? false) ?? false);
+				pattern => raw?.LabelText?.Any(label => label?.Text?.RemoveXmlTag()?.RegexMatchSuccess(pattern, System.Text.RegularExpressions.RegexOptions.IgnoreCase) ?? false) ?? false);
 
 			var LabelAnyRegexMatchSuccessIgnoreCase = new Func<string[], bool>(
 				setPattern => setPattern?.Any(LabelRegexMatchSuccessIgnoreCase) ?? false);


### PR DESCRIPTION
This commit also fix problem when “EP-S Gaussian Scoped Mining Laser” was not correctly registered as a mining device. More info here: https://forum.botengine.org/t/scoped-mining-laser-isminer/579/11?u=achurilo