### PR TITLE
Add support for root-address flag when reading from saved sample

### DIFF
--- a/implement/read-memory-64-bit/Program.cs
+++ b/implement/read-memory-64-bit/Program.cs
@@ -124,6 +124,22 @@ class Program
                     return (memoryReader, uiRootCandidatesAddresses);
                 }
 
+                (IMemoryReader, IImmutableList<ulong>) GetMemoryReaderAndWithSpecifiedRootFromProcessSampleFile(byte[] processSampleFile, ulong rootAddress)
+                {
+                    var processSampleId = Pine.CommonConversion.StringBase16FromByteArray(
+                        Pine.CommonConversion.HashSHA256(processSampleFile));
+
+                    Console.WriteLine($"Reading from process sample {processSampleId}.");
+
+                    var processSampleUnpacked = ProcessSample.ProcessSampleFromZipArchive(processSampleFile);
+
+                    var memoryReader = new MemoryReaderFromProcessSample(processSampleUnpacked.memoryRegions);
+
+                    Console.WriteLine($"Reading UIRoot from specified address: {rootAddress}");
+
+                    return (memoryReader, ImmutableList<ulong>.Empty.Add(rootAddress));
+                }
+
                 (IMemoryReader, IImmutableList<ulong>) GetMemoryReaderAndRootAddresses()
                 {
                     if (processId.HasValue)
@@ -139,6 +155,11 @@ class Program
                     if (!(0 < sourceFileArgument?.Length))
                     {
                         throw new Exception("Where should I read from?");
+                    }
+
+                    if (0 < rootAddressArgument?.Length)
+                    {
+                        return GetMemoryReaderAndWithSpecifiedRootFromProcessSampleFile(System.IO.File.ReadAllBytes(sourceFileArgument), ParseULong(rootAddressArgument));
                     }
 
                     return GetMemoryReaderAndRootAddressesFromProcessSampleFile(System.IO.File.ReadAllBytes(sourceFileArgument));


### PR DESCRIPTION
Add support for root-address flag when reading from saved sample.

Sanderling does not support `--root-address` flag and ignores it when reading from saved process sample. With support for the `--root-address` flag, it is no longer necessary to run a search for UIRoot candidates. It is enough to specify the address. Also it speeds up the program execution when root-address is known.