### PR TITLE
Skip process sampling when process Id is processId is provided

### DIFF
--- a/implement/read-memory-64-bit/Program.cs
+++ b/implement/read-memory-64-bit/Program.cs
@@ -128,12 +128,9 @@ class Program
                 {
                     if (processId.HasValue)
                     {
-                        if (0 < rootAddressArgument?.Length)
-                        {
-                            return (new MemoryReaderFromLiveProcess(processId.Value), ImmutableList.Create(ParseULong(rootAddressArgument)));
-                        }
+                        var possibleRootAddresses = 0 < rootAddressArgument?.Length ? ImmutableList.Create(ParseULong(rootAddressArgument)) : EveOnline64.EnumeratePossibleAddressesForUIRootObjectsFromProcessId(processId.Value);
 
-                        return GetMemoryReaderAndRootAddressesFromProcessSampleFile(GetProcessSampleFileFromProcessId(processId.Value));
+                        return (new MemoryReaderFromLiveProcess(processId.Value), possibleRootAddresses);
                     }
 
                     if (!(0 < sourceFileArgument?.Length))


### PR DESCRIPTION
To address issue in: https://github.com/Arcitectus/Sanderling/issues/83#issue-1813049189
This code change will:

1. Reduces the memory (<2G) as it does not "read content" when calling ReadCommittedMemoryRegionsFromProcessId.
2. Speeds up the root search step by a little (~20 seconds) when processId is provided. 
3. Removes dependency on the screenshots, so the command does not fail even when the window is not focused.