### PR TITLE
feat: add Cli app for frontend

### DIFF
--- a/implement/alternate-ui/source/elm.json
+++ b/implement/alternate-ui/source/elm.json
@@ -6,6 +6,7 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
+            "albertdahlin/elm-posix": "1.1.0",
             "danfishgold/base64-bytes": "1.1.0",
             "dillonkearns/elm-markdown": "7.0.1",
             "elm/browser": "1.0.2",

--- a/implement/alternate-ui/source/src/Frontend/Cli.elm
+++ b/implement/alternate-ui/source/src/Frontend/Cli.elm
@@ -113,28 +113,23 @@ encodeDictEntriesOfInterest _ =
     E.null
 
 
-encodeTotalDisplayRegion : DisplayRegion -> E.Value
-encodeTotalDisplayRegion _ =
-    E.null
-
-
-encodeTotalDisplayRegionVisible : DisplayRegion -> E.Value
-encodeTotalDisplayRegionVisible _ =
-    E.null
-
-
-encodeSelfDisplayRegion : DisplayRegion -> E.Value
-encodeSelfDisplayRegion _ =
-    E.null
+encodeDisplayRegion : DisplayRegion -> E.Value
+encodeDisplayRegion region =
+    E.object 
+        [ ("x", E.int region.x)
+        , ("y", E.int region.y)
+        , ("width", E.int region.width)
+        , ("height", E.int region.height)
+        ]
 
 
 encodeNodeWithChildren : UITreeNodeWithDisplayRegion -> E.Value
 encodeNodeWithChildren node =
     E.object
         [ ( "uiNode", encodeUiNodeWithChildren node.uiNode )
-        , ( "totalDisplayRegion", encodeTotalDisplayRegion node.totalDisplayRegion )
-        , ( "totalDisplayRegionVisible", encodeTotalDisplayRegionVisible node.totalDisplayRegionVisible )
-        , ( "selfDisplayRegion", encodeSelfDisplayRegion node.selfDisplayRegion )
+        , ( "totalDisplayRegion", encodeDisplayRegion node.totalDisplayRegion )
+        , ( "totalDisplayRegionVisible", encodeDisplayRegion node.totalDisplayRegionVisible )
+        , ( "selfDisplayRegion", encodeDisplayRegion node.selfDisplayRegion )
         , ( "children", encodeChildren node.children )
         ]
 

--- a/implement/alternate-ui/source/src/Frontend/Cli.elm
+++ b/implement/alternate-ui/source/src/Frontend/Cli.elm
@@ -1,0 +1,109 @@
+module Frontend.Cli exposing (program)
+
+import EveOnline.MemoryReading
+import EveOnline.ParseUserInterface exposing (UITreeNodeWithDisplayRegion)
+import Json.Decode
+import Json.Encode as E
+import Posix.IO as IO exposing (IO, Process)
+import Posix.IO.File as File
+import Posix.IO.Process as Proc
+
+
+program : Process -> IO ()
+program process =
+    case process.argv of
+        [ _, filename ] ->
+            IO.do
+                (File.contentsOf filename
+                    |> IO.exitOnError identity
+                )
+            <|
+                \content ->
+                    case parseMemoryReadingFromJson content of
+                        Ok parsedResult ->
+                            IO.do (Proc.print (E.encode 0 (encodeParsedResult parsedResult))) <|
+                                \_ ->
+                                    IO.return ()
+
+                        Err err ->
+                            IO.do (Proc.print ("Failed " ++ printError err)) <|
+                                \_ ->
+                                    IO.return ()
+
+        _ ->
+            Proc.logErr "Usage: elm-cli <program> file\n"
+
+
+printError : Json.Decode.Error -> String
+printError err =
+    case err of
+        Json.Decode.Field fieldName subErr ->
+            "Error in field '" ++ fieldName ++ "': " ++ printError subErr
+
+        Json.Decode.Index index subErr ->
+            "Error at index " ++ String.fromInt index ++ ": " ++ printError subErr
+
+        Json.Decode.OneOf subErrors ->
+            let
+                errorMsgs =
+                    List.map printError subErrors
+            in
+            "One of the following errors occurred:\n" ++ String.concat errorMsgs
+
+        Json.Decode.Failure message value ->
+            "Failure: " ++ message ++ ", Value: " ++ E.encode 0 value
+
+
+encodeParsedResult : ParseMemoryReadingSuccess -> E.Value
+encodeParsedResult parsedResult =
+    parsedResult
+        |> List.map encodeNodeWithChildren
+        |> E.list identity
+
+
+encodeChildren : Maybe (List EveOnline.ParseUserInterface.ChildOfNodeWithDisplayRegion) -> E.Value
+encodeChildren maybeChildren =
+    case maybeChildren of
+        Just children ->
+            children
+                |> List.map
+                    (\child ->
+                        case child of
+                            EveOnline.ParseUserInterface.ChildWithRegion childNode ->
+                                encodeNodeWithChildren childNode
+
+                            EveOnline.ParseUserInterface.ChildWithoutRegion _ ->
+                                E.null
+                    )
+                |> E.list identity
+
+        Nothing ->
+            E.null
+
+
+encodeNodeWithChildren : UITreeNodeWithDisplayRegion -> E.Value
+encodeNodeWithChildren node =
+    E.object
+        [ ( "name", E.string node.uiNode.pythonObjectTypeName )
+        , ( "x", E.int node.totalDisplayRegion.x )
+        , ( "y", E.int node.totalDisplayRegion.y )
+        , ( "children", encodeChildren node.children )
+        ]
+
+
+parseMemoryReadingFromJson : String -> Result Json.Decode.Error ParseMemoryReadingSuccess
+parseMemoryReadingFromJson =
+    EveOnline.MemoryReading.decodeMemoryReadingFromString
+        >> Result.map
+            (\uiTree ->
+                let
+                    uiTreeWithDisplayRegion =
+                        uiTree |> EveOnline.ParseUserInterface.parseUITreeWithDisplayRegionFromUITree
+                in
+                uiTreeWithDisplayRegion
+                    :: (uiTreeWithDisplayRegion |> EveOnline.ParseUserInterface.listDescendantsWithDisplayRegion)
+            )
+
+
+type alias ParseMemoryReadingSuccess =
+    List UITreeNodeWithDisplayRegion


### PR DESCRIPTION
EDIT: this is equally as much to learn from. Might not lead anywhere. Im trying to figure out one thing by doing something else (figuring out how coordinates are calculated from offsets, by outputting the ui tree to json and learning sanderling and the elm code). 

Allow to output UI with coords to json in a cli app

install elm posix cli 

`npm install -g @albertdahlin/elm-posix`

run with 

`elm-cli run src/Frontend/Cli.elm .\eve-online-memory-reading.json > result.json`

- [ ] Either get some approval for this kind of thing in this repo or make a semi official fork
- [x] Test it with an actual memory reading 
- [x] Handle ChildWithoutRegion
- [x] Add more data in the json encoding step
- [ ] avoid repetition by memoization? due to recursive manner uiNodes are repeated